### PR TITLE
Use correct path separator for current OS

### DIFF
--- a/WhiskerMan.m
+++ b/WhiskerMan.m
@@ -137,8 +137,8 @@ handles.tracking2D=false;
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % specify folders in next 2 lines:
-        handles.dir.h =[pwd '\'];
-        handles.dir.v =[pwd '\vertical_view\'];
+        handles.dir.h = fullfile(pwd, filesep);
+        handles.dir.v = fullfile(pwd, 'vertical_view', filesep);
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 d = handles.dir.h;


### PR DESCRIPTION
This presents user with a drop-down list of files,
even when not running on Windows.